### PR TITLE
correct license link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ The data workflow is further described in the [wiki](https://github.com/ktoddbro
 
 ## License
 
-[MIT License](LICENSE.md)
+[MIT License](LICENSE)


### PR DESCRIPTION
removed '.md' from end of URL as that file has been removed

I did not use the fork method as this is just fixing a typo.